### PR TITLE
Add reusable eslint config npm package

### DIFF
--- a/styleguides/eslint-config-lystable/.gitignore
+++ b/styleguides/eslint-config-lystable/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/styleguides/eslint-config-lystable/README.md
+++ b/styleguides/eslint-config-lystable/README.md
@@ -1,7 +1,7 @@
 Lystable Javascript ESLint config
 =================================
 
-Our default export contains all of our ESLint rules, including EcmaScript 6+ and React. It requires eslint and eslint-plugin-react.
+Our default export contains all of our ESLint rules, including EcmaScript 6+ and React. It requires `eslint` and `eslint-plugin-react`.
 
-1. Install with `npm install --save-dev eslint-config-lystable` 
+1. Install with `npm install --save-dev eslint eslint-config-lystable eslint-plugin-react` 
 2. Add `"extends": "lystable"` to your .eslintrc

--- a/styleguides/eslint-config-lystable/README.md
+++ b/styleguides/eslint-config-lystable/README.md
@@ -1,0 +1,7 @@
+Lystable Javascript ESLint config
+=================================
+
+Our default export contains all of our ESLint rules, including EcmaScript 6+ and React. It requires eslint and eslint-plugin-react.
+
+1. Install with `npm install --save-dev eslint-config-lystable` 
+2. Add `"extends": "lystable"` to your .eslintrc

--- a/styleguides/eslint-config-lystable/index.js
+++ b/styleguides/eslint-config-lystable/index.js
@@ -1,0 +1,41 @@
+module.exports = {
+  "plugins": ["react"],
+  // Extend AirBnB style guide - https://github.com/airbnb/javascript
+  "extends": "lystable/node_modules/eslint-config-airbnb",
+  // on top of the AirBnB guide...
+  "rules": {
+    "no-use-before-define": [2, "nofunc"],
+    "no-console": 2,
+    "no-loop-func": 0,
+    "indent": [2, 2, {"SwitchCase": 1}],
+    "quotes": [2, "single", "avoid-escape"],
+    "no-nested-ternary": 0,
+    "padded-blocks": 0,
+    "space-infix-ops": 0,
+    "object-curly-spacing": [2, "never"],
+    "array-bracket-spacing": [2, "never"],
+    "computed-property-spacing": [2, "never"],
+    "space-in-brackets": 0,
+    "space-before-function-paren": [2, { "anonymous": "never", "named": "never" }],
+    // react rules - https://github.com/yannickcr/eslint-plugin-react
+    "react/no-multi-comp": [2, {"ignoreStateless": true}],
+    "react/jsx-max-props-per-line": 0,
+    "react/jsx-no-duplicate-props": 2,
+    "react/jsx-pascal-case": 2,
+    "react/no-direct-mutation-state": 2,
+    "react/jsx-key": 2,
+    "react/prop-types": 2,
+    "react/jsx-indent": [2, 2],
+    "react/jsx-indent-props": [2, 2],
+    "react/jsx-boolean-value": [2, "always"],
+    "react/jsx-closing-bracket-location": [2, "tag-aligned"],
+    // TODO: rules which aren't quite working right...
+    "react/display-name": [0, {"acceptTranspilerName": true}], // captures any function returning jsx
+    // TODO: rules to roll in over time...
+    "comma-dangle": [0, "always-multiline"],
+    "react/jsx-handler-names": 0,
+    "react/forbid-prop-types": 0,
+    "react/jsx-no-bind": 0,
+    "react/no-string-refs": 0
+  }
+};

--- a/styleguides/eslint-config-lystable/package.json
+++ b/styleguides/eslint-config-lystable/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "eslint-config-lystable",
+  "version": "1.0.0",
+  "description": "Base eslint config conforming to Lystable development guidelines",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "eslint",
+    "javascript",
+    "config",
+    "lystable"
+  ],
+  "author": {
+    "name": "Chris Pearce",
+    "url": "https://twitter.com/@chrisui"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lystable/guidelines.git"
+  },
+  "devDependencies": {
+    "eslint-config-airbnb": "^2.1.1",
+    "eslint-plugin-react": "^3.14.0"
+  },
+  "peerDependencies": {
+    "eslint": ">=1.0.0"
+  }
+}

--- a/styleguides/eslint-config-lystable/package.json
+++ b/styleguides/eslint-config-lystable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lystable",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Base eslint config conforming to Lystable development guidelines",
   "main": "index.js",
   "scripts": {
@@ -21,9 +21,8 @@
     "type": "git",
     "url": "git+https://github.com/lystable/guidelines.git"
   },
-  "devDependencies": {
-    "eslint-config-airbnb": "^2.1.1",
-    "eslint-plugin-react": "^3.14.0"
+  "dependencies": {
+    "eslint-config-airbnb": "^2.1.1"
   },
   "peerDependencies": {
     "eslint": ">=1.0.0"

--- a/styleguides/javascript.md
+++ b/styleguides/javascript.md
@@ -7,6 +7,9 @@ We follow the excellent styleguide provided by
 Exceptions or extensions to the specifics discussed in that guide are
 documented here or in project specific documentation.
 
+### Eslint Config
+Use the base Lystable eslint config for your Javascript projects! Find details [here](eslint-config-lystable).
+
 Function definition
 -------------------
 Extending the [Airbnb Function Rules](https://github.com/airbnb/javascript#functions)...


### PR DESCRIPTION
When published to npm this will allow us to re-use linter configuration in any project using javascript.

See: https://www.npmjs.com/package/eslint-config-lystable