### PR TITLE
Make the airbnb config a peer dependency for npm3 support

### DIFF
--- a/styleguides/eslint-config-lystable/index.js
+++ b/styleguides/eslint-config-lystable/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   "plugins": ["react"],
   // Extend AirBnB style guide - https://github.com/airbnb/javascript
-  "extends": "lystable/node_modules/eslint-config-airbnb",
+  "extends": "eslint-config-airbnb",
   // on top of the AirBnB guide...
   "rules": {
     "no-use-before-define": [2, "nofunc"],

--- a/styleguides/eslint-config-lystable/package.json
+++ b/styleguides/eslint-config-lystable/package.json
@@ -21,10 +21,8 @@
     "type": "git",
     "url": "git+https://github.com/lystable/guidelines.git"
   },
-  "dependencies": {
-    "eslint-config-airbnb": "^2.1.1"
-  },
   "peerDependencies": {
+    "eslint-config-airbnb": "^2.1.1",
     "eslint": ">=1.0.0"
   }
 }


### PR DESCRIPTION
Follow up pr in lystable-frontend to add `eslint-config-airbnb` to dev dependencies